### PR TITLE
Use Vuex for job theme (?), react on changes in views & layouts, and …

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <template>
-  <v-app class="job_theme--default">
+  <v-app>
     <component :is="layout">
       <router-view/>
     </component>
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
-import { mapActions } from 'vuex'
+import { mapActions, mapMutations } from 'vuex'
 
 const DEFAULT_LAYOUT = 'empty'
 const DEFAULT_URL = '/'
@@ -46,7 +46,8 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['setBaseUrl'])
+    ...mapActions(['setBaseUrl']),
+    ...mapMutations(['app/setJobTheme'])
   },
   created () {
     let baseUrl = DEFAULT_URL
@@ -56,9 +57,12 @@ export default {
     this.setBaseUrl(baseUrl)
   },
   mounted () {
+    // set application font-size in HTML top-level element
     if (localStorage.fontSize) {
       document.getElementsByTagName('html')[0].style.fontSize = localStorage.fontSize
     }
+    // set Job icons theme found in LocalStorage in Vuex
+    this['app/setJobTheme'](localStorage.jobTheme)
   }
 }
 </script>

--- a/src/components/cylc/Drawer.vue
+++ b/src/components/cylc/Drawer.vue
@@ -63,6 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <v-subheader>Workflows</v-subheader>
       <g-scan
         :workflows="workflows"
+        :job-theme="jobTheme"
       />
     </v-list>
     <template v-slot:append>
@@ -87,6 +88,11 @@ export default {
   components: {
     GScan,
     'c-header': Header
+  },
+  props: {
+    jobTheme: {
+      type: String
+    }
   },
   data: () => ({
     responsive: false,

--- a/src/components/cylc/Job.vue
+++ b/src/components/cylc/Job.vue
@@ -21,7 +21,7 @@
 -->
 
 <template functional>
-  <span>
+  <span :class="[props.theme || 'job_theme--default']">
     <span
       class="c-job"
       style="display:inline-block; vertical-align:middle"
@@ -58,6 +58,9 @@ export default {
     status: {
       type: String,
       required: true
+    },
+    theme: {
+      type: String
     }
   }
 }

--- a/src/components/cylc/gscan/GScan.vue
+++ b/src/components/cylc/gscan/GScan.vue
@@ -59,7 +59,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         dark
                         text
                       >
-                        <job :status="state" />
+                        <job
+                          :status="state"
+                          :theme="jobTheme"
+                        />
                       </v-btn>
                     </template>
                     <!-- tooltip text -->
@@ -111,6 +114,9 @@ export default {
     workflows: {
       type: Array,
       required: true
+    },
+    jobTheme: {
+      type: String
     }
   },
   data () {

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -78,6 +78,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       :node="workflow"
       :hoverable="hoverable"
       :initialExpanded="expanded"
+      :job-theme="jobTheme"
       v-on:tree-item-created="onTreeItemCreated"
       v-on:tree-item-destroyed="onTreeItemDestroyed"
       v-on:tree-item-expanded="onTreeItemExpanded"
@@ -108,7 +109,8 @@ export default {
     },
     hoverable: Boolean,
     activable: Boolean,
-    multipleActive: Boolean
+    multipleActive: Boolean,
+    jobTheme: String
   },
   components: {
     Task,

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -57,14 +57,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div v-if="!isExpanded" class="node-summary">
           <!-- Task summary -->
           <job
-              v-for="(task, index) in node.children"
-              :key="`${task.id}-summary-${index}`"
-              :status="task.node.state" />
+            v-for="(task, index) in node.children"
+            :key="`${task.id}-summary-${index}`"
+            :status="task.node.state"
+            :theme="jobTheme"
+          />
         </div>
       </div>
       <div :class="getNodeDataClass()" v-else-if="node.type === 'job'">
         <div :class="getNodeDataClass()" @click="jobNodeClicked">
-          <job :status="node.node.state" />
+          <job
+            :status="node.node.state"
+            :theme="jobTheme"
+          />
           <span class="mx-1">#{{ node.node.submitNum }}</span>
           <span class="grey--text">{{ node.node.host }}</span>
         </div>
@@ -93,6 +98,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           :depth="depth + 1"
           :hoverable="hoverable"
           :initialExpanded="initialExpanded"
+          :job-theme="jobTheme"
           v-on:tree-item-created="$listeners['tree-item-created']"
           v-on:tree-item-destroyed="$listeners['tree-item-destroyed']"
           v-on:tree-item-expanded="$listeners['tree-item-expanded']"
@@ -136,7 +142,8 @@ export default {
     initialExpanded: {
       type: Boolean,
       default: true
-    }
+    },
+    jobTheme: String
   },
   data () {
     return {

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -19,7 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <div>
     <ConnectionStatus :is-offline="offline" />
     <toolbar v-if="!workflowViews.includes($route.name)" />
-    <drawer />
+    <drawer
+      :job-theme="jobTheme"
+    />
 
     <v-main>
       <alert />
@@ -70,7 +72,10 @@ export default {
   },
 
   computed: {
-    ...mapState(['offline'])
+    ...mapState(['offline']),
+    ...mapState({
+      jobTheme: state => `job_theme--${state.app.jobTheme}`
+    })
   },
 
   errorCaptured (error, vm, info) {

--- a/src/store/app.module.js
+++ b/src/store/app.module.js
@@ -18,7 +18,8 @@
 const state = {
   drawer: null,
   color: 'success',
-  title: null
+  title: null,
+  jobTheme: null
 }
 
 const mutations = {
@@ -33,6 +34,9 @@ const mutations = {
   },
   setTitle (state, title) {
     state.title = title
+  },
+  setJobTheme (state, jobTheme) {
+    state.jobTheme = jobTheme
   }
 }
 

--- a/src/views/Tree.vue
+++ b/src/views/Tree.vue
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         :activable="false"
         :multiple-active="false"
         :min-depth="1"
+        :job-theme="jobTheme"
         ref="tree0"
         key="tree0"
       ></tree-component>
@@ -39,6 +40,7 @@ import CylcTree from '@/components/cylc/tree/cylc-tree'
 import { WORKFLOW_TREE_DELTAS_SUBSCRIPTION } from '@/graphql/queries'
 import Alert from '@/model/Alert.model'
 import { applyDeltas } from '@/components/cylc/tree/deltas'
+import { mapState } from 'vuex'
 
 export default {
   mixins: [
@@ -74,6 +76,12 @@ export default {
      */
     tree: new CylcTree()
   }),
+
+  computed: {
+    ...mapState({
+      jobTheme: state => `job_theme--${state.app.jobTheme}`
+    })
+  },
 
   /**
    * Called when the user enters the view. This is executed before the component is fully

--- a/src/views/UserProfile.vue
+++ b/src/views/UserProfile.vue
@@ -179,7 +179,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapState, mapMutations } from 'vuex'
 import { mixin } from '@/mixins'
 import {
   resetFontSize,
@@ -231,20 +231,13 @@ export default {
     resetFontSize,
     decreaseFontSize,
     increaseFontSize,
-    getCurrentFontSize
+    getCurrentFontSize,
+    ...mapMutations(['app/setJobTheme'])
   },
   watch: {
-    jobTheme: (theme) => {
+    jobTheme: function (theme) {
       localStorage.jobTheme = theme
-
-      // set job theme in app
-      const ele = document.getElementById('app')
-      for (const className of ele.classList) {
-        if (className.startsWith('job_theme--')) {
-          ele.classList.remove(className)
-        }
-      }
-      ele.classList.add(`job_theme--${theme}`)
+      this['app/setJobTheme'](theme)
     }
   }
 }

--- a/src/views/Workflow.vue
+++ b/src/views/Workflow.vue
@@ -38,6 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         >
           <tree-component
             :workflows="tree.root.children"
+            :job-theme="jobTheme"
           />
         </v-skeleton-loader>
         <v-skeleton-loader
@@ -132,6 +133,9 @@ export default {
   computed: {
     ...mapState('workflows', ['workflows']),
     ...mapState('user', ['user']),
+    ...mapState({
+      jobTheme: state => `job_theme--${state.app.jobTheme}`
+    }),
     treeWidgets () {
       return Object
         .entries(this.widgets)


### PR DESCRIPTION
…pass the theme as a prop in the component

@oliver-sanders not the best way to achieve this I think, just started adding changes until I got the theme set in Vuex, and other views/layout reacting to this value.

Then set the theme as a prop in the `Job` component.

I have been trying to keep Vuex away from components, and using it only in views. This forces the components to have as little state as possible, and zero Vuex, which IMO has made maintaining these components easier.

But even if we wanted to use Vuex directly in the `Job` component, I don't know if that would work, as `Job` is a functional component (only props, no data, no computed). The functional marker enforces the immutability on the component, and also enforces the Vue design of props-down (and events-up).

Feel free to use any parts of this PR if you'd like :+1: it was just to show how I would approach it more or less