### PR TITLE
Make tree items indent line up perfectly using relative units

### DIFF
--- a/src/components/cylc/tree/GScanTreeItem.vue
+++ b/src/components/cylc/tree/GScanTreeItem.vue
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     v-bind="{ node, depth, filteredOutNodesCache, hoverable }"
     :auto-expand-types="$options.nodeTypes"
     :render-expand-collapse-btn="node.type !== 'workflow'"
-    :indent="18"
     ref="treeItem"
   >
     <WorkflowIcon
@@ -29,7 +28,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       v-cylc-object="node"
       :class="nodeClass"
       class="flex-shrink-0"
-      style="margin: 0 2px;"
     />
     <v-list-item
       :to="workflowLink"

--- a/src/components/cylc/tree/JobDetails.vue
+++ b/src/components/cylc/tree/JobDetails.vue
@@ -58,7 +58,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 </template>
 
 <script>
-import { nodeContentPad } from '@/components/cylc/tree/TreeItem.vue'
+import { getIndent } from '@/components/cylc/tree/util'
 import {
   formatDuration,
   jobMessageOutputs
@@ -72,8 +72,8 @@ export default {
       type: Object,
       required: true,
     },
-    /** Indent in px */
-    indent: {
+    /** Indent level */
+    depth: {
       type: Number,
       required: true,
     },
@@ -86,7 +86,7 @@ export default {
     /** Make the job details triangle point to the job icon */
     leafTriangleStyle () {
       return {
-        'margin-left': `${this.indent + nodeContentPad}px`
+        'margin-left': getIndent(this.depth),
       }
     },
 

--- a/src/components/cylc/tree/Tree.vue
+++ b/src/components/cylc/tree/Tree.vue
@@ -25,7 +25,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       v-for="child of rootChildren"
       :key="child.id"
       :node="child"
-      v-bind="{ hoverable, cyclePointsOrderDesc, expandAll, filteredOutNodesCache, indent }"
+      v-bind="{ hoverable, cyclePointsOrderDesc, expandAll, filteredOutNodesCache }"
     />
   </v-container>
 </template>
@@ -81,11 +81,6 @@ export default {
       required: false,
       default: () => []
     },
-    /** Indent of each tree-item hierarchy in px */
-    indent: {
-      type: Number,
-      required: false
-    }
   },
 
   components: {

--- a/src/components/cylc/tree/TreeItem.vue
+++ b/src/components/cylc/tree/TreeItem.vue
@@ -41,10 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
       <slot v-bind="{ isExpanded }">
         <!-- the node value -->
         <!-- TODO: revisit these node.type values that can be replaced by constants later (and in other components too). -->
-        <div
-          :class="nodeDataClass"
-          :style="nodeDataStyle"
-        >
+        <div :class="nodeDataClass">
           <template v-if="node.type === 'cycle'">
             <!-- NOTE: cycle point nodes don't have any data associated with them
               at present so we must use the root family node for the task icon.
@@ -85,7 +82,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 :key="`${job.id}-summary-${index}`"
                 :status="job.node.state"
                 :previous-state="node.children.length > 1 ? node.children[1].node.state : ''"
-                style="margin-left: 0.25em;"
               />
             </div>
             <span class="mx-1">{{ node.name }}</span>
@@ -160,7 +156,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
           <JobDetails
             v-if="node.type === 'job'"
             v-bind="{ node, meanElapsedTime }"
-            :indent="(depth + 1) * indent"
+            :depth="depth + 1"
           />
           <!-- component recursion -->
           <TreeItem
@@ -170,7 +166,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             :node="child"
             :depth="depth + 1"
             :mean-elapsed-time="meanElapsedTime ?? node.node.task?.meanElapsedTime"
-            v-bind="{ hoverable, autoExpandTypes, cyclePointsOrderDesc, expandAll, filteredOutNodesCache, indent }"
+            v-bind="{ hoverable, autoExpandTypes, cyclePointsOrderDesc, expandAll, filteredOutNodesCache }"
           />
         </template>
       </slot>
@@ -187,12 +183,7 @@ import {
   latestJob,
   jobMessageOutputs
 } from '@/utils/tasks'
-import { getNodeChildren } from '@/components/cylc/tree/util'
-
-export const defaultNodeIndent = 28 // px
-
-/** Margin between expand/collapse btn & node content */
-export const nodeContentPad = 6 // px
+import { getIndent, getNodeChildren } from '@/components/cylc/tree/util'
 
 export default {
   name: 'TreeItem',
@@ -237,12 +228,6 @@ export default {
       type: WeakMap,
       required: true,
     },
-    /** Indent in px; default is expand/collapse btn width */
-    indent: {
-      type: Number,
-      required: false,
-      default: defaultNodeIndent
-    },
     /** Pass mean run time from task down to (grand)child job details */
     meanElapsedTime: {
       type: Number,
@@ -285,13 +270,9 @@ export default {
         ? null
         : getNodeChildren(this.node, this.cyclePointsOrderDesc)
     },
-    /** Get the node indentation in units of px. */
-    nodeIndentation () {
-      return this.depth * this.indent
-    },
     nodeStyle () {
       return {
-        'padding-left': `${this.nodeIndentation}px`
+        'padding-left': getIndent(this.depth)
       }
     },
     nodeClass () {
@@ -302,11 +283,6 @@ export default {
     },
     nodeDataClass () {
       return ['node-data', `node-data-${this.node.type}`]
-    },
-    nodeDataStyle () {
-      return {
-        marginLeft: `${nodeContentPad}px`,
-      }
     },
     expandCollapseBtnStyle () {
       return {

--- a/src/components/cylc/tree/util.js
+++ b/src/components/cylc/tree/util.js
@@ -31,3 +31,7 @@ export function getNodeChildren (node, cyclePointsOrderDesc) {
   }
   return node.children
 }
+
+export function getIndent (depth) {
+  return `calc(${depth} * var(--tree-indent))`
+}

--- a/src/styles/cylc/_gscan.scss
+++ b/src/styles/cylc/_gscan.scss
@@ -24,9 +24,7 @@
 }
 
 .c-gscan {
-  .v-skeleton-loader > div:first-child {
-    background: inherit;
-  }
+  --tree-indent: 1rem;
   .c-gscan-workflows {
     .c-gscan-workflow {
       .c-workflow-stopped {
@@ -44,7 +42,7 @@
       }
 
       .c-treeitem {
-        margin: 4px 0;
+        margin: 0.25em 0;
 
         .c-treeitem {
           margin: 0;

--- a/src/styles/cylc/_tree.scss
+++ b/src/styles/cylc/_tree.scss
@@ -31,8 +31,12 @@ $line-height: 1.8em;
  */
 $visible-outputs: 5;
 
-/* Task/job icon size. */
-$icon-size: 1.2em;
+// Task/job/expand/collapse icon width
+$icon-width: 1.5rem;
+
+:root {
+  --tree-indent: #{$icon-width};
+}
 
 @mixin active-state() {
   background-color: $active-color;
@@ -51,7 +55,9 @@ $icon-size: 1.2em;
   .c-task, .c-job {
     display: flex;
     align-items: center;
-    font-size: $icon-size;
+    justify-content: center;
+    font-size: 1.2em;
+    width: $icon-width;
   }
 }
 
@@ -64,10 +70,10 @@ $icon-size: 1.2em;
     display: block;
 
     .node-expand-collapse-button {
-      width: 1.5em;
-      height: 1.5em;
-      margin: 0 2px;
+      width: $icon-width;
+      height: $icon-width;
       cursor: pointer;
+      user-select: none;
     }
 
     .node-expand-collapse-button::after {
@@ -97,11 +103,8 @@ $icon-size: 1.2em;
       }
     }
   }
-  .type {
-    margin-right: 10px;
-  }
 
-  $arrow-size: calc($icon-size / 2);
+  $arrow-size: calc($icon-width / 2);
   $leaf-background-color: map-get(settings.$grey, 'lighten-3');
 
   .leaf {
@@ -144,7 +147,7 @@ $icon-size: 1.2em;
         // 5 outputs, plus a buffer of 1.0em that appears to give the scroll just the
         // right space to show the N items in the scroll (without the buffer the last
         // item is partially hidden).
-        max-height: calc(#{$line-height} * #{$visible-outputs} + 1.0em);
+        max-height: calc($line-height * $visible-outputs + 1.0em);
         overflow-y: auto;
       }
     }

--- a/tests/e2e/specs/tree.cy.js
+++ b/tests/e2e/specs/tree.cy.js
@@ -16,10 +16,6 @@
  */
 
 import TaskState from '@/model/TaskState.model'
-import {
-  defaultNodeIndent,
-  nodeContentPad,
-} from '@/components/cylc/tree/TreeItem.vue'
 
 describe('Tree view', () => {
   it('Should display cycle points for the mocked workflow', () => {
@@ -94,7 +90,7 @@ describe('Tree view', () => {
     // The leaf node has a triangle pointing to the job icon - check the margin
     // is applied (node is 5 levels deep):
     cy.get('.leaf:visible:first > .arrow-up')
-      .should('have.css', 'margin-left', `${5 * defaultNodeIndent + nodeContentPad}px`)
+      .should('have.css', 'margin-left', `${5 * 24}px`)
   })
   it('Updates view correctly', () => {
     cy.visit('/#/tree/one')


### PR DESCRIPTION
(When cylc/cylc-ui#1642 is merged into this branch)